### PR TITLE
cleaned up remotecontrol intent

### DIFF
--- a/src/d/alexa-openwebif/source/intents/remotecontrol.d
+++ b/src/d/alexa-openwebif/source/intents/remotecontrol.d
@@ -39,7 +39,7 @@ abstract class RemoteControlBaseIntent : OpenWebifBaseIntent
 		if (checkBox(boxinfo.info.imagedistro, action, code))
 		{
 			Remotecontrol rc;
-			// is needed because an call on about doesn't need authorization - this one does - so catch auth errors
+
 			try
 				rc = apiClient.remotecontrol(code);
 			catch (Exception e)


### PR DESCRIPTION
close #139 
this comment was total bullshit :) the about call needs an auth as well. But anyway the try catch is still needed to catch errors with api call